### PR TITLE
Make mkdir.sync opts parameter optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module mkdirp {
     mode: number;
   }
 
-  export function sync (path: string, opts: mkdirp.Opts): string;
+  export function sync (path: string, opts?: mkdirp.Opts): string;
 }
 
 export = mkdirp;


### PR DESCRIPTION
In the JavaScript API this `opts` object is optional, I figure that the TypeScript definition should reflect that.
